### PR TITLE
Use a URLFlag and URL.ResolveReference.

### DIFF
--- a/gddo-server/main.go
+++ b/gddo-server/main.go
@@ -856,7 +856,7 @@ var (
 	sidebarEnabled  = flag.Bool("sidebar", false, "Enable package page sidebar.")
 	defaultGOOS     = flag.String("default_goos", "", "Default GOOS to use when building package documents.")
 	trustProxy      = flag.Bool("trust_proxy_headers", false, "If enabled, identify the remote address of the request using X-Real-Ip in header.")
-	sourcegraphURL  = flag.String("sourcegraph_url", "https://sourcegraph.com", "Link to global uses on Sourcegraph based at this URL (no need for trailing slash).")
+	sourcegraphURL  = URLFlag("sourcegraph_url", "https://sourcegraph.com", "Link to global uses on Sourcegraph based at this URL.")
 )
 
 func main() {

--- a/gddo-server/template.go
+++ b/gddo-server/template.go
@@ -107,7 +107,7 @@ func (pdoc *tdoc) SourceLink(pos doc.Pos, text string, textOnlyOK bool) htemp.HT
 
 // UsesLink generates a link to uses of a symbol definition.
 func (pdoc *tdoc) UsesLink(title string, defParts ...string) htemp.HTML {
-	if *sourcegraphURL == "" {
+	if sourcegraphURL.URL == (url.URL{}) {
 		return ""
 	}
 
@@ -136,8 +136,10 @@ func (pdoc *tdoc) UsesLink(title string, defParts ...string) htemp.HTML {
 		def = typeName + "/" + methodName
 	}
 
-	q := url.Values{"repo": {pdoc.ProjectRoot}, "pkg": {pdoc.ImportPath}, "def": {def}}
-	u := *sourcegraphURL + "/-/godoc/refs?" + q.Encode()
+	u := sourcegraphURL.ResolveReference(&url.URL{
+		Path:     "/-/godoc/refs",
+		RawQuery: url.Values{"repo": {pdoc.ProjectRoot}, "pkg": {pdoc.ImportPath}, "def": {def}}.Encode(),
+	}).String()
 	return htemp.HTML(fmt.Sprintf(`<a class="uses" title="%s" href="%s">Uses</a>`, htemp.HTMLEscapeString(title), htemp.HTMLEscapeString(u)))
 }
 

--- a/gddo-server/util.go
+++ b/gddo-server/util.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/url"
+)
+
+// URLFlag defines a URL flag with specified name, default value, and usage string.
+// The return value is the address of a urlFlag variable that stores the value of the flag.
+// URLFlag panics if it fails to parse default value with url.Parse.
+func URLFlag(name string, value string, usage string) *urlFlag {
+	url, err := url.Parse(value)
+	if err != nil {
+		panic(fmt.Errorf("URLFlag: default value failed to url.Parse: %v", err))
+	}
+	p := &urlFlag{URL: *url}
+	flag.CommandLine.Var(p, name, usage)
+	return p
+}
+
+// urlFlag implements flag.Value for a url.URL flag.
+type urlFlag struct{ url.URL }
+
+func (u *urlFlag) Set(s string) error {
+	url, err := url.Parse(s)
+	if err != nil {
+		return err
+	}
+	u.URL = *url
+	return nil
+}
+
+func (u *urlFlag) String() string { return u.URL.String() }


### PR DESCRIPTION
This improves type safety. If supplied an invalid URL that fails to `url.Parse`, then `flag.Parse()` will provide an error.

Previously, string concatenation was used to construct the final URL, taking "https://sourcegraph.com" + "/-/refs?" + query. But that means if there was a trailing slash in the url, like -sourcegraph_url="https://sourcegraph.com/" then there'd be two slashes in the final url.

Using `URL.ResolveReference` resolves that.

The only disadvantage is slight additional verbosity of code (but hopefully readability is improved).

/cc @sqs
